### PR TITLE
feat: 仮トップページを新規作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,4 +56,5 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "minitest", "~> 5.20"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,9 +139,7 @@ GEM
     marcel (1.1.0)
     matrix (0.4.3)
     mini_mime (1.1.5)
-    minitest (6.0.4)
-      drb (~> 2.0)
-      prism (~> 1.5)
+    minitest (5.27.0)
     msgpack (1.8.0)
     net-imap (0.6.3)
       date
@@ -309,6 +307,7 @@ DEPENDENCIES
   debug
   jbuilder
   jsbundling-rails
+  minitest (~> 5.20)
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2)

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,0 +1,4 @@
+class TopController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/top_helper.rb
+++ b/app/helpers/top_helper.rb
@@ -1,0 +1,2 @@
+module TopHelper
+end

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,0 +1,25 @@
+<div class="text-center px-6 py-12">
+  <h1 class="text-2xl font-bold mb-4">
+    “伝わらない”をなくす、説明力トレーニング
+  </h1>
+
+  <p class="text-gray-600 mb-6">
+    相手を設定して説明を書くと、AIがフィードバック。<br>
+    分かりやすい説明力を実践的に鍛えられます。
+  </p>
+
+  <div class="bg-gray-200 h-48 mb-6 flex items-center justify-center">
+    UIイメージ or 図
+  </div>
+
+  <ul class="text-sm text-gray-700 space-y-1 mb-8">
+    <li>✔ 自分の理解度がわかる</li>
+    <li>✔ 説明の型が身につく</li>
+    <li>✔ AIが客観的に評価</li>
+  </ul>
+
+  <div class="flex flex-col sm:flex-row gap-4 justify-center">
+   <%= link_to "ログイン", "#", class: "w-1/4 text-center bg-blue-500 text-white py-4 rounded-2xl font-bold text-lg opacity-80 hover:opacity-100" %>
+   <%= link_to "新規登録", "#",class: "w-1/4 text-center bg-red-500 text-white py-4 rounded-2xl font-bold text-lg shadow-md" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
+  get "top/index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
+  root "top#index"
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,17 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 0) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/test/controllers/top_controller_test.rb
+++ b/test/controllers/top_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class TopControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get top_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
仮のトップページを作成 close #5 

## 実装内容
- Topコントローラーを作成
- rootをtop#indexに設定
- トップページのビューを作成
  - サービス概要の表示
  - 新規登録・ログインボタンの設置

## 補足
デザインは仮実装のため、今後調整予定