### PR TITLE
Feature/#17 devise signup

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,6 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,11 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  # allow_browser versions: :modern
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  end
 end

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -19,7 +19,7 @@
   </ul>
 
   <div class="flex flex-col sm:flex-row gap-4 justify-center">
-   <%= link_to "ログイン", "#", class: "w-1/4 text-center bg-blue-500 text-white py-4 rounded-2xl font-bold text-lg opacity-80 hover:opacity-100" %>
-   <%= link_to "新規登録", "#",class: "w-1/4 text-center bg-red-500 text-white py-4 rounded-2xl font-bold text-lg shadow-md" %>
+   <%= link_to "ログイン", new_user_session_path, class: "w-1/4 text-center bg-blue-500 text-white py-4 rounded-2xl font-bold text-lg opacity-80 hover:opacity-100" %>
+   <%= link_to "新規登録", new_user_registration_path,class: "w-1/4 text-center bg-red-500 text-white py-4 rounded-2xl font-bold text-lg shadow-md" %>
   </div>
 </div>


### PR DESCRIPTION
## 概要

会員登録処理に関する実装を行った。
Deviseのデフォルト機能をベースに、ユーザー名（name）の保存とトップページからの導線を追加。
close #17 

## 実装内容

* Devise の会員登録処理の拡張

  * `name` カラムを登録時に保存できるように設定
  * `ApplicationController` にてストロングパラメータを追加
* トップページから新規登録ページへの導線を追加

## 確認方法

* トップページから「新規登録」リンクをクリックし、登録画面へ遷移できること
* 必要項目を入力し、ユーザー登録が正常に行えること
* 登録後にエラーが発生しないこと

## 補足

* 登録後のリダイレクト先については、別issue（ホーム画面作成）で対応予定

