### PR TITLE
Feature/#18 login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,12 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  # ログイン後の遷移
+  def after_sign_in_path_for(resource)
+    root_path
+  end
+
+  # Deviseパラメータ許可
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
   end

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,4 +1,22 @@
 <div class="text-center px-6 py-12">
+  <% if user_signed_in? %>
+  <p>ようこそ <%= current_user.name %></p>
+
+  <%= link_to "ログアウト",
+    destroy_user_session_path,
+    data: { turbo_method: :delete },
+    class: "text-red-500" %>
+
+  <% else %>
+  <%= link_to "ログイン",
+    new_user_session_path,
+    class: "text-blue-500" %>
+
+  <%= link_to "新規登録",
+    new_user_registration_path,
+    class: "bg-blue-500 text-white px-4 py-2 rounded" %>
+  <% end %>
+
   <h1 class="text-2xl font-bold mb-4">
     “伝わらない”をなくす、説明力トレーニング
   </h1>


### PR DESCRIPTION
## 概要

ログイン／ログアウト処理の実装。
Deviseのデフォルト機能をベースに、ログイン後の遷移制御とログイン状態に応じたUI表示の切り替えを追加
close #18 

## 変更内容

* ログイン後のリダイレクト先を設定
* ログアウト機能の追加
* ログイン状態に応じたUI出し分けを実装

## 確認方法

* 正しい情報でログインできること
* ログイン後、トップページにリダイレクトされること
* ログイン後はユーザー名とログアウトリンクが表示されること
* ログアウト後、未ログイン状態の表示に戻ること
 
## 補足

* ログイン後の遷移先は現時点では `root_path` に設定（今後ホーム画面実装時に変更予定）
