### PR TITLE
Feature/#9 home

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   # ログイン後の遷移
   def after_sign_in_path_for(resource)
-    root_path
+    home_path
   end
 
   # Deviseパラメータ許可

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,0 +1,2 @@
+module HomeHelper
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Home#index</h1>
+<p>Find me in app/views/home/index.html.erb</p>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,72 @@
-<h1>Home#index</h1>
-<p>Find me in app/views/home/index.html.erb</p>
+<div class="flex min-h-screen bg-gray-100">
+
+  <!-- サイドバー -->
+  <aside class="w-64 bg-gray-900 text-white hidden md:flex flex-col">
+    <div class="p-6 text-xl font-bold border-b border-gray-700 text-yellow-400">
+      言語化 <br>
+      トレーニングジム
+    </div>
+
+    <nav class="flex-1 p-4 space-y-2">
+      <%= link_to "#", class: "block px-4 py-2 rounded hover:bg-gray-700" do %>
+        📊 活動記録
+      <% end %>
+
+      <%= link_to "#", class: "block px-4 py-2 rounded hover:bg-gray-700" do %>
+        ⭐ お気に入り
+      <% end %>
+
+      <%= link_to "#", class: "block px-4 py-2 rounded hover:bg-gray-700" do %>
+        ⚙ 設定
+      <% end %>
+    </nav>
+
+    <div class="p-4 border-t border-gray-800">
+      <%= link_to "ログアウト",
+        destroy_user_session_path,
+      data: { turbo_method: :delete },
+      class: "block text-center bg-yellow-500 hover:bg-yellow-600 text-black font-bold py-2 rounded transition" %>
+    </div>
+  </aside>
+
+  <!-- メイン -->
+  <main class="flex-1 flex flex-col">
+
+    <!-- ヘッダー -->
+    <header class="bg-white shadow px-6 py-4 flex justify-between items-center">
+      <h1 class="text-xl font-bold">ホーム</h1>
+
+      <% if user_signed_in? %>
+        <p class="text-sm text-gray-600">
+          こんにちは、<span class="font-semibold"><%= current_user.name %></span>
+        </p>
+      <% end %>
+    </header>
+
+    <!-- コンテンツ -->
+    <div class="flex-1 flex flex-col items-center justify-center p-6">
+
+      <!-- メインCTA -->
+      <div class="w-full max-w-md text-center">
+        <h2 class="text-lg text-gray-700 mb-6">
+          今日もトレーニングしましょう 💪
+        </h2>
+
+        <%= link_to "#",
+          class: "block w-full bg-blue-600 hover:bg-blue-700 text-white text-lg font-bold py-4 rounded-xl shadow-lg transition" do %>
+          トレーニングを始める
+        <% end %>
+      </div>
+
+      <!-- サブ情報 -->
+      <div class="w-full max-w-md mt-10 bg-white p-6 rounded-xl shadow">
+        <h3 class="font-semibold mb-3">最近の活動</h3>
+        <p class="text-gray-500 text-sm">
+          まだ記録がありません
+        </p>
+      </div>
+
+    </div>
+  </main>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 Rails.application.routes.draw do
+  get "home/index"
   devise_for :users
-  get "top/index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root "top#index"
+
+  get "home", to: "home#index"
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class HomeControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get home_index_url
+    assert_response :success
+  end
+end

--- a/test/controllers/top_controller_test.rb
+++ b/test/controllers/top_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class TopControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get top_index_url
+    get root_url
     assert_response :success
   end
 end


### PR DESCRIPTION
## 概要

ログイン後に表示されるホーム画面を新規作成。

close #9 

## 実装内容

* ホーム画面の基礎構造を作成
* ホーム画面のUIを実装
  * サイドバー付きレイアウトを採用（PC向け）
  * メインエリアに「トレーニング開始」ボタンを配置
* ログイン後の遷移先を変更

## 確認方法

* ログイン後、ホーム画面（`/home`）へ遷移すること
* 「トレーニング開始」ボタンが表示されること
* ログアウトが正常に動作し、トップページへ戻ること

## 補足

* サイドバー内の一部リンク（活動記録・お気に入り等）は未実装のため、暫定的にダミーリンク（`#`）を設定。