### PR TITLE
Feature/#23 training detail

### DIFF
--- a/app/controllers/trainings_controller.rb
+++ b/app/controllers/trainings_controller.rb
@@ -17,8 +17,12 @@ class TrainingsController < ApplicationController
       redirect_to trainings_path, notice: "トレーニングを保存しました"
     else
       @targets = Target.all
-      render :index, status: :unprocessable_entity
+      render :new, status: :unprocessable_entity
     end
+  end
+
+  def show
+    @training = current_user.trainings.find(params[:id])
   end
 end
 

--- a/app/views/trainings/index.html.erb
+++ b/app/views/trainings/index.html.erb
@@ -13,7 +13,7 @@
     <% if @trainings.any? %>
       <div class="space-y-4">
         <% @trainings.each do |training| %>
-          <%= link_to "#", class: "block" do %>
+          <%= link_to training_path(training), class: "block" do %>
             <div class="bg-white p-5 rounded-2xl shadow hover:shadow-md transition border border-gray-100">
 
               <!-- 上部（日時＋ターゲット） -->

--- a/app/views/trainings/show.html.erb
+++ b/app/views/trainings/show.html.erb
@@ -1,0 +1,58 @@
+<div class="flex min-h-screen bg-amber-50 text-gray-800">
+
+  <!-- サイドバー -->
+  <%= render "shared/sidebar" %>
+
+  <!-- メイン -->
+  <main class="flex-1 flex justify-center p-8">
+
+    <div class="w-full max-w-3xl bg-white rounded-2xl shadow-md p-8">
+
+      <!-- タイトル -->
+      <h1 class="text-2xl font-bold text-amber-500 mb-6">
+        🏋️ トレーニング詳細
+      </h1>
+
+      <!-- 日付 -->
+      <p class="text-sm text-gray-400 mb-4">
+        <%= @training.created_at.strftime("%Y/%m/%d %H:%M") %>
+      </p>
+
+      <!-- テーマ -->
+      <div class="mb-6">
+        <h2 class="text-sm text-gray-400 mb-1">テーマ</h2>
+        <p class="text-lg font-bold"><%= @training.theme %></p>
+      </div>
+
+      <!-- 相手 -->
+      <div class="mb-6">
+        <h2 class="text-sm text-gray-400 mb-1">相手</h2>
+        <span class="inline-block bg-amber-100 text-amber-600 px-3 py-1 rounded-full text-sm">
+          <%= @training.display_target %>
+        </span>
+      </div>
+
+      <!-- 説明 -->
+      <div class="mb-6">
+        <h2 class="text-sm text-gray-400 mb-1">説明内容</h2>
+        <div class="bg-amber-50 p-4 rounded-lg whitespace-pre-wrap">
+          <%= @training.explanation %>
+        </div>
+      </div>
+
+      <!-- スコア（仮） -->
+      <div class="mb-6">
+        <h2 class="text-sm text-gray-400 mb-1">スコア</h2>
+        <p class="text-gray-300">※ 未実装</p>
+      </div>
+
+      <!-- AIフィードバック（仮） -->
+      <div>
+        <h2 class="text-sm text-gray-400 mb-1">AIフィードバック</h2>
+        <p class="text-gray-300">※ 未実装</p>
+      </div>
+
+    </div>
+
+  </main>
+</div>

--- a/app/views/trainings/show.html.erb
+++ b/app/views/trainings/show.html.erb
@@ -4,9 +4,17 @@
   <%= render "shared/sidebar" %>
 
   <!-- メイン -->
-  <main class="flex-1 flex justify-center p-8">
+  <main class="flex-1 p-8">
 
-    <div class="w-full max-w-3xl bg-white rounded-2xl shadow-md p-8">
+    <!-- 🔙 戻るリンク（左上） -->
+    <div class="mb-4">
+      <%= link_to trainings_path, class: "inline-flex items-center text-sm text-gray-500 hover:text-amber-500 transition" do %>
+        ← 戻る
+      <% end %>
+    </div>
+
+    <!-- コンテンツ -->
+    <div class="max-w-3xl mx-auto bg-white rounded-2xl shadow p-8">
 
       <!-- タイトル -->
       <h1 class="text-2xl font-bold text-amber-500 mb-6">
@@ -14,19 +22,21 @@
       </h1>
 
       <!-- 日付 -->
-      <p class="text-sm text-gray-400 mb-4">
+      <p class="text-sm text-gray-400 mb-6">
         <%= @training.created_at.strftime("%Y/%m/%d %H:%M") %>
       </p>
 
       <!-- テーマ -->
       <div class="mb-6">
-        <h2 class="text-sm text-gray-400 mb-1">テーマ</h2>
-        <p class="text-lg font-bold"><%= @training.theme %></p>
+        <p class="text-sm text-gray-400 mb-1">テーマ</p>
+        <p class="text-lg font-bold text-gray-800">
+          <%= @training.theme %>
+        </p>
       </div>
 
       <!-- 相手 -->
       <div class="mb-6">
-        <h2 class="text-sm text-gray-400 mb-1">相手</h2>
+        <p class="text-sm text-gray-400 mb-1">相手</p>
         <span class="inline-block bg-amber-100 text-amber-600 px-3 py-1 rounded-full text-sm">
           <%= @training.display_target %>
         </span>
@@ -34,22 +44,26 @@
 
       <!-- 説明 -->
       <div class="mb-6">
-        <h2 class="text-sm text-gray-400 mb-1">説明内容</h2>
-        <div class="bg-amber-50 p-4 rounded-lg whitespace-pre-wrap">
+        <p class="text-sm text-gray-400 mb-1">説明内容</p>
+        <div class="bg-amber-50 border border-amber-100 p-4 rounded-lg whitespace-pre-wrap leading-relaxed">
           <%= @training.explanation %>
         </div>
       </div>
 
-      <!-- スコア（仮） -->
+      <!-- スコア -->
       <div class="mb-6">
-        <h2 class="text-sm text-gray-400 mb-1">スコア</h2>
-        <p class="text-gray-300">※ 未実装</p>
+        <p class="text-sm text-gray-400 mb-1">スコア</p>
+        <div class="bg-gray-50 p-4 rounded-lg text-gray-300">
+          未実装
+        </div>
       </div>
 
-      <!-- AIフィードバック（仮） -->
+      <!-- AIフィードバック -->
       <div>
-        <h2 class="text-sm text-gray-400 mb-1">AIフィードバック</h2>
-        <p class="text-gray-300">※ 未実装</p>
+        <p class="text-sm text-gray-400 mb-1">AIフィードバック</p>
+        <div class="bg-gray-50 p-4 rounded-lg text-gray-300">
+          未実装
+        </div>
       </div>
 
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root "top#index"
 
   get "home", to: "home#index"
-  resources :trainings, only: %i[ index new create ]
+  resources :trainings, only: %i[ index new create show ]
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
## 概要
トレーニング履歴一覧から各トレーニングの詳細を表示する機能を実装しました。

close #23 

## 実装内容

- トレーニング詳細ページのルーティングを追加
- trainings#showを実装
  - current_userに紐づくトレーニングのみ取得
- トレーニング履歴から詳細ページへ遷移できるようリンクを修正
- トレーニング詳細ページのUI実装

## 動作確認
- トレーニング一覧から詳細ページへ遷移できることを確認
- ログインユーザーのデータのみ表示されることを確認

## 補足
- スコアおよびAIフィードバックは別issueで実装予定