### PR TITLE
feat: トレーニング詳細にAIフィードバックを表示

### DIFF
--- a/app/views/trainings/show.html.erb
+++ b/app/views/trainings/show.html.erb
@@ -1,22 +1,15 @@
 <div class="flex min-h-screen bg-amber-50 text-gray-800">
-
-  <!-- サイドバー -->
   <%= render "shared/sidebar" %>
-
-  <!-- メイン -->
   <main class="flex-1 p-8">
 
-    <!-- 🔙 戻るリンク（左上） -->
     <div class="mb-4">
       <%= link_to trainings_path, class: "inline-flex items-center text-sm text-gray-500 hover:text-amber-500 transition" do %>
         ← 戻る
       <% end %>
     </div>
 
-    <!-- コンテンツ -->
     <div class="max-w-3xl mx-auto bg-white rounded-2xl shadow p-8">
 
-      <!-- タイトル -->
       <h1 class="text-2xl font-bold text-amber-500 mb-6">
         🏋️ トレーニング詳細
       </h1>
@@ -26,23 +19,35 @@
         <%= @training.created_at.strftime("%Y/%m/%d %H:%M") %>
       </p>
 
-      <!-- テーマ -->
-      <div class="mb-6">
-        <p class="text-sm text-gray-400 mb-1">テーマ</p>
-        <p class="text-lg font-bold text-gray-800">
-          <%= @training.theme %>
-        </p>
+      <% feedback = @training.ai_feedback %>
+
+      <div class="mb-6 grid grid-cols-1 md:grid-cols-3 gap-4">
+
+        <div>
+          <p class="text-sm text-gray-400 mb-1">テーマ</p>
+          <p class="text-lg font-bold text-gray-800">
+            <%= @training.theme %>
+          </p>
+        </div>
+
+        <div>
+          <p class="text-sm text-gray-400 mb-1">相手</p>
+          <span class="inline-block bg-amber-100 text-amber-600 px-3 py-1 rounded-full text-sm">
+            <%= @training.display_target %>
+          </span>
+        </div>
+
+        <% if feedback.present? %>
+          <div>
+            <p class="text-sm text-gray-400 mb-1">スコア</p>
+            <p class="text-lg font-bold text-amber-600">
+              <%= feedback.score %>点
+            </p>
+          </div>
+        <% end %>
+
       </div>
 
-      <!-- 相手 -->
-      <div class="mb-6">
-        <p class="text-sm text-gray-400 mb-1">相手</p>
-        <span class="inline-block bg-amber-100 text-amber-600 px-3 py-1 rounded-full text-sm">
-          <%= @training.display_target %>
-        </span>
-      </div>
-
-      <!-- 説明 -->
       <div class="mb-6">
         <p class="text-sm text-gray-400 mb-1">説明内容</p>
         <div class="bg-amber-50 border border-amber-100 p-4 rounded-lg whitespace-pre-wrap leading-relaxed">
@@ -50,21 +55,38 @@
         </div>
       </div>
 
-      <!-- スコア -->
-      <div class="mb-6">
-        <p class="text-sm text-gray-400 mb-1">スコア</p>
-        <div class="bg-gray-50 p-4 rounded-lg text-gray-300">
-          未実装
-        </div>
-      </div>
+        <% if @training.ai_feedback.present? %>
+          <div class="mt-8 space-y-5">
 
-      <!-- AIフィードバック -->
-      <div>
-        <p class="text-sm text-gray-400 mb-1">AIフィードバック</p>
-        <div class="bg-gray-50 p-4 rounded-lg text-gray-300">
-          未実装
-        </div>
-      </div>
+            <div class="p-4 border border-green-200 bg-green-50 rounded-lg">
+              <h2 class="font-semibold text-green-600 mb-2">
+                👍 良い点
+              </h2>
+              <p class="text-gray-700 whitespace-pre-line">
+                <%= feedback.good_points %>
+              </p>
+            </div>
+
+            <div class="p-4 border border-red-200 bg-red-50 rounded-lg">
+              <h2 class="font-semibold text-red-600 mb-2">
+                🔧 改善点
+              </h2>
+              <p class="text-gray-700 whitespace-pre-line">
+                <%= feedback.improvement_points %>
+              </p>
+            </div>
+
+            <div class="p-4 border border-amber-200 bg-amber-50 rounded-lg">
+              <h2 class="font-semibold text-amber-600 mb-2">
+                📝 総評
+              </h2>
+              <p class="text-gray-700 whitespace-pre-line">
+                <%= feedback.overall_comment %>
+              </p>
+            </div>
+
+          </div>
+        <% end %>
 
     </div>
 


### PR DESCRIPTION
## 概要

トレーニング詳細ページにAIフィードバックを表示し、UIレイアウトを改善。

close #27 

## 実装内容

* トレーニング詳細ページ（show）にAIフィードバックを表示
* テーマ・相手・スコアを横並びで表示するレイアウトに変更

## 動作確認

- トレーニング履歴から任意の詳細ページに遷移
- テーマ・相手・スコアが横並びで表示されていること
- AIフィードバック（良い点・改善点・総評）が表示されること
