### PR TITLE
feat: バリデーションエラーメッセージを日本語化

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ module Myapp
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
+    config.i18n.default_locale = :ja
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,16 @@
+ja:
+  activerecord:
+    models:
+      training: トレーニング
+    attributes:
+      training:
+        theme: テーマ
+        explanation: 説明
+        target: 相手
+        custom_target: 相手（その他）
+
+  errors:
+    messages:
+      blank: "を入力してください"
+      too_short: "は%{count}文字以上で入力してください"
+      too_long: "は%{count}文字以下で入力してください"


### PR DESCRIPTION
## 概要

バリデーションエラーメッセージの日本語化対応。

close #54 

## 実装内容

* i18nの設定を追加し、デフォルトロケールを日本語に変更
* `config/locales/ja.yml` を作成・編集

## 動作確認

・各項目を空白で保存し、日本語でエラーメッセージが表示されることを確認。
