### PR TITLE
feat: トレーニング作成フォームにラベルを追加し入力項目の可読性を向上

### DIFF
--- a/app/views/trainings/new.html.erb
+++ b/app/views/trainings/new.html.erb
@@ -27,19 +27,23 @@
             </div>
             <% end %>
 
+            <%= f.label :theme, "テーマ", class: "block text-sm font-semibold text-gray-600 mb-1" %>
             <%= f.text_field :theme,
-              placeholder: "テーマ",
+              placeholder: "説明するテーマを入力してください",
               class: "w-full px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
 
+            <%= f.label :target_id, "説明する相手", class: "block text-sm font-semibold text-gray-600 mb-1" %>
             <%= f.collection_select :target_id, @targets, :id, :name, {},
               class: "w-full px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
 
+            <%= f.label :custom_target, "その他の相手", class: "block text-sm font-semibold text-gray-600 mb-1" %>
             <%= f.text_field :custom_target,
-              placeholder: "その他の場合入力",
+              placeholder: "説明したい相手を入力してください",
               class: "w-full px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
 
+            <%= f.label :explanation, "説明内容", class: "block text-sm font-semibold text-gray-600 mb-1" %>
             <%= f.text_area :explanation,
-              placeholder: "説明を書いてください...",
+              placeholder: "相手に合わせて説明してみましょう",
               class: "w-full h-40 px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
 
             <%= f.submit "トレーニング完了",


### PR DESCRIPTION
## 概要

トレーニング作成フォームのUIを改善し、入力項目の分かりやすさを向上。

close #60 

## 実装内容

* 各入力項目にラベルを追加
* 入力内容がイメージしやすいようプレースホルダーを調整

## 確認方法

* トレーニング作成画面で各項目にラベルが表示されていることを確認
* 入力時に何を記入すればよいか分かりやすくなっていることを確認
