### PR TITLE
feat: その他選択時に入力フィールドを表示する処理を追加

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,22 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+
+document.addEventListener("turbo:load", () => {
+  const select = document.getElementById("training_target_id");
+  const customField = document.getElementById("custom-target-field");
+
+  if (!select || !customField) return;
+
+  const toggle = () => {
+    if (select.selectedOptions[0].text === "その他") {
+      customField.classList.remove("hidden");
+    } else {
+      customField.classList.add("hidden");
+    }
+  };
+
+  select.addEventListener("change", toggle);
+
+  toggle();
+});

--- a/app/views/trainings/new.html.erb
+++ b/app/views/trainings/new.html.erb
@@ -36,10 +36,12 @@
             <%= f.collection_select :target_id, @targets, :id, :name, {},
               class: "w-full px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
 
-            <%= f.label :custom_target, "その他の相手", class: "block text-sm font-semibold text-gray-600 mb-1" %>
-            <%= f.text_field :custom_target,
-              placeholder: "説明したい相手を入力してください",
-              class: "w-full px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
+            <div id="custom-target-field" class="<%= 'hidden' unless @training.target&.name == 'その他' %>">
+              <%= f.label :custom_target, "その他の相手", class: "block text-sm font-semibold text-gray-600 mb-1" %>
+              <%= f.text_field :custom_target,
+                placeholder: "説明したい相手を入力してください",
+                class: "w-full px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
+            </div>
 
             <%= f.label :explanation, "説明内容", class: "block text-sm font-semibold text-gray-600 mb-1" %>
             <%= f.text_area :explanation,


### PR DESCRIPTION
## 概要

トレーニング作成画面で、「その他」選択時の入力フィールド表示制御を実装。

close #62 

## 実装内容

* 「その他」選択時のみカスタム入力欄を表示するように制御

## 動作確認

* 「その他」を選択すると入力欄が表示されることを確認
* 他の選択肢では非表示になることを確認
