### PR TITLE
feat: ユーザー名のバリデーションを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  validates :name, presence: true
+
   has_many :trainings
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,8 @@ ja:
     models:
       training: トレーニング
     attributes:
+      user:
+        name: ユーザー名
       training:
         theme: テーマ
         explanation: 説明


### PR DESCRIPTION
## 概要

新規登録時にユーザー名が未入力の場合、エラーとなるようバリデーションを追加。

close #64 

## 実装内容

* Userモデルに `name` の presence バリデーションを追加

## 動作確認

* ユーザー名を未入力で新規登録するとエラーが表示されることを確認
* ユーザー名を入力すると正常に登録できることを確認
