### PR TITLE
fix: メール重複時のエラーメッセージを曖昧な表現に変更

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,12 @@ ja:
         explanation: 説明
         target: 相手
         custom_target: 相手（その他）
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              taken: "入力に問題があります"
 
   errors:
     messages:


### PR DESCRIPTION
## 概要

新規登録時のメールアドレス重複エラーメッセージを、アカウント存在が推測されない表現に変更。

## 実装内容

* 「入力に問題があります」に変更

## 目的

* アカウントの存在有無が推測されることを防ぐため（セキュリティ向上）

## 動作確認

* 登録済みメールアドレスで新規登録し、エラーメッセージが変更されていることを確認
