### PR TITLE
fix: パスワードリセットリンクを削除

### DIFF
--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -6,10 +6,6 @@
   <p><%= link_to "Sign up", new_registration_path(resource_name) %></p>
 <% end %>
 
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <p><%= link_to "Forgot your password?", new_password_path(resource_name) %></p>
-<% end %>
-
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <p><%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %></p>
 <% end %>


### PR DESCRIPTION
## 概要

ログイン画面に表示されていたパスワードリセットリンクを削除しました。

## 背景

パスワードリセット機能は未実装のため

## 確認方法

* ログイン画面にパスワードリセットリンクが表示されないことを確認
