### PR TITLE
fix: カスタムターゲットがAIプロンプトに反映されるよう修正

### DIFF
--- a/app/models/training.rb
+++ b/app/models/training.rb
@@ -11,7 +11,11 @@ class Training < ApplicationRecord
   has_one :ai_feedback, dependent: :destroy
 
   def display_target
-    target.name == "その他" ? custom_target : target.name
+    if target&.name == "その他"
+      custom_target.presence || "未設定"
+    else
+      target&.name || "未設定"
+    end
   end
 
   private

--- a/app/services/openai/feedback_generator.rb
+++ b/app/services/openai/feedback_generator.rb
@@ -55,7 +55,7 @@ module Openai
       }
 
       テーマ: #{training.theme}
-      相手: #{training.target&.name || training.custom_target}
+      相手: #{training.display_target}
       説明:
       #{training.explanation}
 


### PR DESCRIPTION
## 概要

「その他」選択時に入力したカスタムターゲットがAIプロンプトに反映されるよう修正。

## 実装内容

* ターゲットのロジックを修正し、条件に応じて `custom_target` を使用するよう変更

## 動作確認

* 「その他」を選択し任意の相手を入力した場合、その内容がAIフィードバックに反映されることを確認
