### PR TITLE
GitHub ActionsでRSpecを実行するよう変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,19 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install JavaScript dependencies
+        run: yarn install
+
+      - name: Build assets
+        run: |
+          yarn build
+          yarn build:css
+
       - name: Run RSpec
         env:
           RAILS_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      - name: Run tests
+      - name: Run RSpec
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/myapp_test
@@ -77,7 +77,7 @@ jobs:
           # REDIS_URL: redis://localhost:6379/0
         run: |
           bin/rails db:prepare
-          bin/rails test
+          bundle exec rspec
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 概要

GitHub Actionsのテスト実行をMinitestからRSpecへ変更

close #76

## 実装内容

* CI設定のテスト実行コマンドを `bin/rails test` から `bundle exec rspec` へ変更
* GitHub Actions上でRSpecが自動実行されるよう設定

## 動作確認

* GitHub Actionsが正常に実行される
* RSpecが正常に実行される
