### PR TITLE
履歴ページのUI調整

### DIFF
--- a/app/views/trainings/index.html.erb
+++ b/app/views/trainings/index.html.erb
@@ -11,7 +11,7 @@
     </h1>
 
     <% if @trainings.any? %>
-      <div class="space-y-4">
+      <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
         <% @trainings.each do |training| %>
           <%= link_to training_path(training), class: "block" do %>
             <div class="bg-white p-5 rounded-2xl shadow hover:shadow-md transition border border-gray-100">

--- a/app/views/trainings/index.html.erb
+++ b/app/views/trainings/index.html.erb
@@ -27,26 +27,26 @@
                   テーマ
                 </p>
 
-                <h2 class="text-lg font-bold text-gray-800 break-words">
+                <h2 class="truncate text-lg font-bold text-gray-800 break-words">
                   <%= training.theme %>
                 </h2>
               </div>
 
               <!-- 相手とスコア -->
-              <div class="flex justify-between mb-5">
+              <div class="flex justify-between gap-4">
 
-                <div>
-                  <p class="text-xs text-gray-500 mb-1">
+                <div class="min-w-0 mb-5">
+                  <p class="text-xs text-gray-500">
                     説明相手
                   </p>
 
-                  <p class="text-gray-800">
+                  <p class="truncate text-gray-800">
                     <%= training.display_target %>
                   </p>
                 </div>
 
-                <div class="text-right">
-                  <p class="text-xs text-gray-500 mb-1">
+                <div class="shrink-0 text-right">
+                  <p class="text-xs text-gray-500">
                     スコア
                   </p>
 

--- a/app/views/trainings/index.html.erb
+++ b/app/views/trainings/index.html.erb
@@ -14,7 +14,7 @@
       <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
         <% @trainings.each do |training| %>
           <%= link_to training_path(training), class: "block" do %>
-            <div class="bg-white p-5 rounded-2xl shadow hover:shadow-md transition border border-gray-100">
+            <div class="bg-white rounded-2xl shadow-md hover:shadow-lg transition p-6 h-full border border-gray-100">
 
               <!-- 上部（日時＋ターゲット） -->
               <div class="flex justify-between items-center mb-2">

--- a/app/views/trainings/index.html.erb
+++ b/app/views/trainings/index.html.erb
@@ -55,6 +55,17 @@
                   </p>
                 </div>
               </div>
+
+              <!-- 説明内容 -->
+              <div>
+                <p class="text-xs text-gray-500 mb-1">
+                  説明内容
+                </p>
+
+                <p class="text-sm text-gray-700 leading-relaxed">
+                  <%= truncate(training.explanation, length: 80) %>
+                </p>
+              </div>
             </div>
           <% end %>
         <% end %>

--- a/app/views/trainings/index.html.erb
+++ b/app/views/trainings/index.html.erb
@@ -16,21 +16,45 @@
           <%= link_to training_path(training), class: "block" do %>
             <div class="bg-white rounded-2xl shadow-md hover:shadow-lg transition p-6 h-full border border-gray-100">
 
-              <!-- 上部（日時＋ターゲット） -->
-              <div class="flex justify-between items-center mb-2">
-                <p class="text-sm text-gray-400">
-                  <%= training.created_at.strftime("%Y/%m/%d") %>
-                </p>
-                <span class="text-xs bg-amber-100 text-amber-600 px-3 py-1 rounded-full">
-                  <%= training.display_target %>
-                </span>
-              </div>
+              <!-- 日付 -->
+              <p class="text-sm text-gray-400 mb-4">
+                <%= training.created_at.strftime("%Y/%m/%d") %>
+              </p>
 
               <!-- テーマ -->
-              <h2 class="text-lg font-bold text-gray-800">
-                <%= training.theme %>
-              </h2>
+              <div class="mb-5">
+                <p class="text-xs text-gray-500 mb-1">
+                  テーマ
+                </p>
 
+                <h2 class="text-lg font-bold text-gray-800 break-words">
+                  <%= training.theme %>
+                </h2>
+              </div>
+
+              <!-- 相手とスコア -->
+              <div class="flex justify-between mb-5">
+
+                <div>
+                  <p class="text-xs text-gray-500 mb-1">
+                    説明相手
+                  </p>
+
+                  <p class="text-gray-800">
+                    <%= training.display_target %>
+                  </p>
+                </div>
+
+                <div class="text-right">
+                  <p class="text-xs text-gray-500 mb-1">
+                    スコア
+                  </p>
+
+                  <p class="font-semibold text-amber-600">
+                    <%= training.ai_feedback&.score || "-" %>点
+                  </p>
+                </div>
+              </div>
             </div>
           <% end %>
         <% end %>


### PR DESCRIPTION
## 概要

トレーニング履歴ページのUIを改善し、一覧表示をカード形式へ変更

close #81 

## 実装内容

* 履歴一覧を縦並びからグリッドレイアウトへ変更
* 各履歴をカード形式で表示
* 表示内容にスコアと説明内容を追加

## 動作確認

* 履歴がカード形式で表示される
* 説明内容が省略表示される
