### PR TITLE
みんなの投稿ページの作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,7 @@
+class PostsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @posts = Post.includes(:training)
+  end
+end

--- a/app/controllers/trainings_controller.rb
+++ b/app/controllers/trainings_controller.rb
@@ -2,7 +2,9 @@ class TrainingsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @trainings = current_user.trainings.order(created_at: :desc)
+    @trainings = current_user.trainings
+                             .includes(:target, :ai_feedback)
+                             .order(created_at: :desc)
   end
 
   def new

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,0 +1,2 @@
+module PostsHelper
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,4 @@
+class Post < ApplicationRecord
+  belongs_to :user
+  belongs_to :training
+end

--- a/app/models/training.rb
+++ b/app/models/training.rb
@@ -9,6 +9,7 @@ class Training < ApplicationRecord
   validate :custom_target_if_needed
 
   has_one :ai_feedback, dependent: :destroy
+  has_one :post, dependent: :destroy
 
   def display_target
     if target&.name == "その他"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,5 +6,6 @@ class User < ApplicationRecord
 
   validates :name, presence: true
 
-  has_many :trainings
+  has_many :trainings, dependent: :destroy
+  has_many :posts, dependent: :destroy
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,32 @@
+<div class="flex min-h-screen bg-amber-50 text-gray-800">
+
+  <%= render "shared/sidebar" %>
+
+  <main class="flex-1 p-8">
+
+    <h1 class="text-2xl font-bold text-amber-500 mb-6">
+      みんなの投稿
+    </h1>
+
+    <% if @posts.any? %>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+        <% @posts.each do |post| %>
+          <%= render "trainings/training_card",
+              training: post.training %>
+        <% end %>
+      </div>
+
+    <% else %>
+
+      <div class="text-center mt-20">
+        <p class="text-gray-400">
+          まだ投稿がありません
+        </p>
+      </div>
+
+    <% end %>
+
+  </main>
+
+</div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -17,6 +17,10 @@
       📊 活動記録
     <% end %>
 
+    <%= link_to posts_path, class: "block px-4 py-2 rounded hover:bg-gray-700" do %>
+      🌎 みんなの投稿
+    <% end %>
+
     <%= link_to "#", class: "block px-4 py-2 rounded hover:bg-gray-700" do %>
       ⭐ お気に入り
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       get :result
     end
   end
+  resources :posts, only: %i[index]
 
   get "terms", to: "static_pages#terms"
   get "privacy_policy", to: "static_pages#privacy_policy"

--- a/db/migrate/20260604091413_create_posts.rb
+++ b/db/migrate/20260604091413_create_posts.rb
@@ -1,0 +1,10 @@
+class CreatePosts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :posts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :training, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_29_023828) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_04_091413) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,15 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_29_023828) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["training_id"], name: "index_ai_feedbacks_on_training_id"
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "training_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["training_id"], name: "index_posts_on_training_id"
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "targets", force: :cascade do |t|
@@ -57,6 +66,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_29_023828) do
   end
 
   add_foreign_key "ai_feedbacks", "trainings"
+  add_foreign_key "posts", "trainings"
+  add_foreign_key "posts", "users"
   add_foreign_key "trainings", "targets"
   add_foreign_key "trainings", "users"
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :post do
+    user { nil }
+    training { nil }
+  end
+end

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PostsHelper. For example:
+#
+# describe PostsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PostsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Posts", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 概要

みんなの投稿機能の実装に向けて、投稿用モデルの作成と関連設定を追加
あわせて、履歴一覧画面で発生していたN+1問題を解消

close #82 

## 実装内容

* Postモデルを作成
* UserとPostの関連付けを追加
* 投稿機能実装に向けた基盤を整備
* Trainings一覧画面に `includes(:target, :ai_feedback)` を追加
* 履歴一覧画面のN+1問題を解消

## 動作確認

* マイグレーション実行後に正常に起動する
* 履歴ページが正常に表示される
* ログを確認し、N+1問題が解消されている


