### PR TITLE
ソート機能を追加

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -5,7 +5,6 @@ class FavoritesController < ApplicationController
     @q = current_user.favorite_trainings.ransack(params[:q])
     @trainings = @q.result
                    .includes(:target, :ai_feedback)
-                   .order(created_at: :desc)
   end
 
   def create

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -3,8 +3,8 @@ class FavoritesController < ApplicationController
 
   def index
     @q = current_user.favorite_trainings.ransack(params[:q])
-    @trainings = @q.result
-                   .includes(:target, :ai_feedback)
+    @q.sorts = "created_at desc" if @q.sorts.empty?
+    @trainings = @q.result.includes(:target, :ai_feedback)
   end
 
   def create

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,8 +3,8 @@ class PostsController < ApplicationController
 
   def index
     @q = Post.joins(:training).ransack(params[:q])
-    @posts = @q.result
-               .includes(training: [ :target, :ai_feedback ])
+    @q.sorts = "created_at desc" if @q.sorts.empty?
+    @posts = @q.result.includes(training: [ :target, :ai_feedback ])
   end
 
   def create

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
 
   def index
     @q = Post.joins(:training).ransack(params[:q])
-    @posts = @q.result(distinct: true)
+    @posts = @q.result
                .includes(training: [ :target, :ai_feedback ])
                .order(created_at: :desc)
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,6 @@ class PostsController < ApplicationController
     @q = Post.joins(:training).ransack(params[:q])
     @posts = @q.result
                .includes(training: [ :target, :ai_feedback ])
-               .order(created_at: :desc)
   end
 
   def create

--- a/app/controllers/trainings_controller.rb
+++ b/app/controllers/trainings_controller.rb
@@ -5,7 +5,6 @@ class TrainingsController < ApplicationController
     @q = current_user.trainings.ransack(params[:q])
     @trainings = @q.result
                    .includes(:target, :ai_feedback, :post)
-                   .order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/trainings_controller.rb
+++ b/app/controllers/trainings_controller.rb
@@ -3,8 +3,8 @@ class TrainingsController < ApplicationController
 
   def index
     @q = current_user.trainings.ransack(params[:q])
-    @trainings = @q.result
-                   .includes(:target, :ai_feedback, :post)
+    @q.sorts = "created_at desc" if @q.sorts.empty?
+    @trainings = @q.result.includes(:target, :ai_feedback, :post)
   end
 
   def new

--- a/app/models/ai_feedback.rb
+++ b/app/models/ai_feedback.rb
@@ -1,3 +1,7 @@
 class AiFeedback < ApplicationRecord
   belongs_to :training
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[score]
+  end
 end

--- a/app/models/training.rb
+++ b/app/models/training.rb
@@ -26,7 +26,7 @@ class Training < ApplicationRecord
   end
 
   def self.ransackable_associations(auth_object = nil)
-    %w[target]
+    %w[target ai_feedback]
   end
 
   private

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -7,6 +7,8 @@
   url: favorites_path,
   search_key: :theme_or_explanation_or_target_name_cont,
   sort_options: [
+    ["作成日（降順）", "created_at desc"],
+    ["作成日（昇順）", "created_at asc"],
     ["スコア（降順）", "ai_feedback_score desc"],
     ["スコア（昇順）", "ai_feedback_score asc"]
   ]) %>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -7,7 +7,6 @@
   url: favorites_path,
   search_key: :theme_or_explanation_or_target_name_cont,
   sort_options: [
-    ["並び替え", ""],
     ["スコア（降順）", "ai_feedback_score desc"],
     ["スコア（昇順）", "ai_feedback_score asc"]
   ]) %>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -5,7 +5,12 @@
 <%= render("shared/search_form",
   q: @q,
   url: favorites_path,
-  search_key: :theme_or_explanation_or_target_name_cont) %>
+  search_key: :theme_or_explanation_or_target_name_cont,
+  sort_options: [
+    ["並び替え", ""],
+    ["スコア（降順）", "ai_feedback_score desc"],
+    ["スコア（昇順）", "ai_feedback_score asc"]
+  ]) %>
 
 <% if @trainings.any? %>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -7,7 +7,6 @@
   url: posts_path,
   search_key: :training_theme_or_training_explanation_or_training_target_name_cont,
   sort_options: [
-    ["並び替え", ""],
     ["スコア（降順）", "training_ai_feedback_score desc"],
     ["スコア（昇順）", "training_ai_feedback_score asc"]
   ]) %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,7 +5,12 @@
 <%= render("shared/search_form",
   q: @q,
   url: posts_path,
-  search_key: :training_theme_or_training_explanation_or_training_target_name_cont) %>
+  search_key: :training_theme_or_training_explanation_or_training_target_name_cont,
+  sort_options: [
+    ["並び替え", ""],
+    ["スコア（降順）", "training_ai_feedback_score desc"],
+    ["スコア（昇順）", "training_ai_feedback_score asc"]
+  ]) %>
 
 <% if @posts.any? %>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -7,6 +7,8 @@
   url: posts_path,
   search_key: :training_theme_or_training_explanation_or_training_target_name_cont,
   sort_options: [
+    ["投稿日（降順）", "created_at desc"],
+    ["投稿日（昇順）", "created_at asc"],
     ["スコア（降順）", "training_ai_feedback_score desc"],
     ["スコア（昇順）", "training_ai_feedback_score asc"]
   ]) %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -13,8 +13,8 @@
     ) %>
 
     <%= f.select :s,
-      sort_options,
-      {},
+      options_for_select(sort_options, params.dig(:q, :s)),
+      { include_blank: "並び替え" },
       class: "bg-white rounded-lg border border-gray-300 px-4 py-2",
       onchange: "this.form.submit();" %>
 

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -14,7 +14,7 @@
 
     <%= f.select :s,
       options_for_select(sort_options, params.dig(:q, :s)),
-      { include_blank: "並び替え" },
+      {},
       class: "bg-white rounded-lg border border-gray-300 px-4 py-2",
       onchange: "this.form.submit();" %>
 

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -13,11 +13,7 @@
     ) %>
 
     <%= f.select :s,
-      [
-          ["並び替え", ""],
-          ["スコア（降順）", "ai_feedback_score desc"],
-          ["スコア（昇順）", "ai_feedback_score asc"]
-      ],
+      sort_options,
       {},
       class: "bg-white rounded-lg border border-gray-300 px-4 py-2",
       onchange: "this.form.submit();" %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -12,5 +12,14 @@
       class: "bg-amber-400 hover:bg-amber-500 text-white px-4 py-2 rounded-lg"
     ) %>
 
+    <%= f.select :s,
+      [
+          ["並び替え", ""],
+          ["スコア（降順）", "ai_feedback_score desc"],
+          ["スコア（昇順）", "ai_feedback_score asc"]
+      ],
+      {},
+      class: "bg-white rounded-lg border border-gray-300 px-4 py-2" %>
+
   </div>
 <% end %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -19,7 +19,8 @@
           ["スコア（昇順）", "ai_feedback_score asc"]
       ],
       {},
-      class: "bg-white rounded-lg border border-gray-300 px-4 py-2" %>
+      class: "bg-white rounded-lg border border-gray-300 px-4 py-2",
+      onchange: "this.form.submit();" %>
 
   </div>
 <% end %>

--- a/app/views/trainings/index.html.erb
+++ b/app/views/trainings/index.html.erb
@@ -5,7 +5,12 @@
 <%= render("shared/search_form",
   q: @q,
   url: trainings_path,
-  search_key: :theme_or_explanation_or_target_name_cont) %>
+  search_key: :theme_or_explanation_or_target_name_cont,
+  sort_options: [
+    ["並び替え", ""],
+    ["スコア（降順）", "ai_feedback_score desc"],
+    ["スコア（昇順）", "ai_feedback_score asc"]
+  ]) %>
 
 <% if @trainings.any? %>
   <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">

--- a/app/views/trainings/index.html.erb
+++ b/app/views/trainings/index.html.erb
@@ -7,6 +7,8 @@
   url: trainings_path,
   search_key: :theme_or_explanation_or_target_name_cont,
   sort_options: [
+    ["作成日（降順）", "created_at desc"],
+    ["作成日（昇順）", "created_at asc"],
     ["スコア（降順）", "ai_feedback_score desc"],
     ["スコア（昇順）", "ai_feedback_score asc"]
   ]) %>

--- a/app/views/trainings/index.html.erb
+++ b/app/views/trainings/index.html.erb
@@ -7,7 +7,6 @@
   url: trainings_path,
   search_key: :theme_or_explanation_or_target_name_cont,
   sort_options: [
-    ["並び替え", ""],
     ["スコア（降順）", "ai_feedback_score desc"],
     ["スコア（昇順）", "ai_feedback_score asc"]
   ]) %>


### PR DESCRIPTION
## 概要

Ransackを利用したソート機能を追加

close #87 

## 実装内容

- トレーニング履歴ページにソート機能を追加
- みんなの投稿ページにソート機能を追加
- お気に入りページにソート機能を追加
- 作成日（投稿日）昇順・降順ソートを追加
- スコア昇順・降順ソートを追加

## 動作確認

- 各ページでソートが正常に動作すること
- 検索とソートを同時に利用できること