### PR TITLE
ページネーション機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "devise"
 gem "ruby-openai"
 gem "devise-i18n"
 gem "ransack"
+gem "kaminari"
 
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,18 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.19.4)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -373,6 +385,7 @@ DEPENDENCIES
   factory_bot_rails
   jbuilder
   jsbundling-rails
+  kaminari
   minitest (~> 5.20)
   pg (~> 1.1)
   puma (>= 5.0)

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -4,7 +4,7 @@ class FavoritesController < ApplicationController
   def index
     @q = current_user.favorite_trainings.ransack(params[:q])
     @q.sorts = "created_at desc" if @q.sorts.empty?
-    @trainings = @q.result.includes(:target, :ai_feedback)
+    @trainings = @q.result.includes(:target, :ai_feedback).page(params[:page])
   end
 
   def create

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
   def index
     @q = Post.joins(:training).ransack(params[:q])
     @q.sorts = "created_at desc" if @q.sorts.empty?
-    @posts = @q.result.includes(training: [ :target, :ai_feedback ])
+    @posts = @q.result.includes(training: [ :target, :ai_feedback ]).page(params[:page])
   end
 
   def create

--- a/app/controllers/trainings_controller.rb
+++ b/app/controllers/trainings_controller.rb
@@ -4,7 +4,7 @@ class TrainingsController < ApplicationController
   def index
     @q = current_user.trainings.ransack(params[:q])
     @q.sorts = "created_at desc" if @q.sorts.empty?
-    @trainings = @q.result.includes(:target, :ai_feedback, :post)
+    @trainings = @q.result.includes(:target, :ai_feedback, :post).page(params[:page])
   end
 
   def new

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -29,4 +29,6 @@
 
 <% end %>
 
-<%= paginate @trainings %>
+<div class="mt-8 flex justify-center">
+  <%= paginate @trainings %>
+</div>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -28,3 +28,5 @@
   </p>
 
 <% end %>
+
+<%= paginate @trainings %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,14 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%# <%= link_to_unless current_page.first?,
+      "≪",
+      url,
+      class: "px-3 py-2 rounded-lg border border-gray-300 bg-white hover:bg-amber-100" %> %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="px-2 text-gray-500">・・・</span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,14 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%# <%= link_to_unless current_page.last?,
+      "≫",
+      url,
+      class: "px-3 py-2 rounded-lg border border-gray-300 bg-white hover:bg-amber-100" %> %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,14 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?,
+      "次へ",
+      url,
+      class: "px-3 py-2 rounded-lg border border-gray-300 bg-white hover:bg-amber-100 transition" %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,21 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' current' if page.current? %>">
+  <% if page.current? %>
+    <span class="px-3 py-2 rounded-lg bg-amber-400 text-white font-semibold">
+      <%= page %>
+    </span>
+  <% else %>
+    <%= link_to page,
+        url,
+        rel: page.rel,
+        class: "px-3 py-2 rounded-lg border border-gray-300 bg-white hover:bg-amber-100 transition" %>
+  <% end %>
+</span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,23 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="flex justify-center items-center gap-2 mt-8">
+    <%= prev_page_tag unless current_page.first? %>
+
+    <% each_page do |page| %>
+      <% if page.display_tag? %>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? %>
+        <%= gap_tag %>
+      <% end %>
+    <% end %>
+
+    <%= next_page_tag unless current_page.last? %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,14 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?,
+      "前へ",
+      url,
+      class: "px-3 py-2 rounded-lg border border-gray-300 bg-white hover:bg-amber-100 transition" %>
+</span>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -32,4 +32,6 @@
 
 <% end %>
 
-<%= paginate @posts %>
+<div class="mt-8 flex justify-center">
+  <%= paginate @posts %>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -31,3 +31,5 @@
     </div>
 
 <% end %>
+
+<%= paginate @posts %>

--- a/app/views/trainings/index.html.erb
+++ b/app/views/trainings/index.html.erb
@@ -32,4 +32,6 @@
 
 <% end %>
 
-<%= paginate @trainings %>
+<div class="mt-8 flex justify-center">
+  <%= paginate @trainings %>
+</div>

--- a/app/views/trainings/index.html.erb
+++ b/app/views/trainings/index.html.erb
@@ -14,11 +14,13 @@
   ]) %>
 
 <% if @trainings.any? %>
+
   <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
     <% @trainings.each do |training| %>
       <%= render "training_card", training: training %>
     <% end %>
   </div>
+
 <% else %>
 
   <!-- 空状態 -->
@@ -30,3 +32,4 @@
 
 <% end %>
 
+<%= paginate @trainings %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 18
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 3
+  config.default_per_page = 18
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 15
+  config.default_per_page = 3
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 18
+  config.default_per_page = 15
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0


### PR DESCRIPTION
## 概要

Kaminariを導入しページネーション機能を追加

close #89 

## 実装内容

- Kaminariを導入
- トレーニング履歴にページネーションを追加
- みんなの投稿にページネーションを追加
- お気に入り一覧にページネーションを追加
- 1ページあたり18件表示に設定
- ページネーションのUIをTailwindで調整

## 確認項目

- 各一覧ページでページネーションが表示されること
- ページ遷移が正常に動作すること