### PR TITLE
1日のAI利用回数制限を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,11 @@ jobs:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
-      # redis:
-      #   image: redis
-      #   ports:
-      #     - 6379:6379
-      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - name: Install packages
@@ -87,7 +87,7 @@ jobs:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/myapp_test
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          # REDIS_URL: redis://localhost:6379/0
+          REDIS_URL: redis://localhost:6379/0
         run: |
           bin/rails db:prepare
           bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "ruby-openai"
 gem "devise-i18n"
 gem "ransack"
 gem "kaminari"
+gem "redis"
 
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,10 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.30.0)
+      connection_pool
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -391,6 +395,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.2)
   ransack
+  redis
   rspec-rails
   rubocop-rails-omakase
   ruby-openai

--- a/app/controllers/trainings_controller.rb
+++ b/app/controllers/trainings_controller.rb
@@ -21,13 +21,9 @@ class TrainingsController < ApplicationController
       return
     end
 
-    @training = current_user.trainings.build(training_params)
-
-    if @training.save
+    ActiveRecord::Base.transaction do
+      @training = current_user.trainings.create!(training_params)
       result = Openai::FeedbackGenerator.call(@training)
-      AiUsageService.increment(current_user)
-
-      # DBに保存
       AiFeedback.create!(
         training: @training,
         good_points: result["good_points"],
@@ -35,11 +31,20 @@ class TrainingsController < ApplicationController
         overall_comment: result["overall_comment"],
         score: result["score"]
       )
-      redirect_to result_training_path(@training), notice: "トレーニングを保存しました"
-    else
-      @targets = Target.all
-      render :new, status: :unprocessable_entity
+      AiUsageService.increment(current_user)
     end
+
+    redirect_to result_training_path(@training), notice: "トレーニングを保存しました"
+
+  rescue StandardError => e
+    Rails.logger.error(e)
+
+    @training ||= current_user.trainings.build(training_params)
+    @targets = Target.all
+
+    flash.now[:alert] = "AIフィードバックの生成に失敗しました"
+
+    render :new, status: :unprocessable_entity
   end
 
   def show

--- a/app/controllers/trainings_controller.rb
+++ b/app/controllers/trainings_controller.rb
@@ -13,12 +13,21 @@ class TrainingsController < ApplicationController
   end
 
   def create
+    if AiUsageService.limit_reached?(current_user)
+      redirect_back(
+        fallback_location: trainings_path,
+        alert: "本日のAI利用回数の上限に達しました"
+      )
+      return
+    end
+
     @training = current_user.trainings.build(training_params)
 
     if @training.save
       result = Openai::FeedbackGenerator.call(@training)
+      AiUsageService.increment(current_user)
 
-      # 👇 DBに保存
+      # DBに保存
       AiFeedback.create!(
         training: @training,
         good_points: result["good_points"],

--- a/app/controllers/trainings_controller.rb
+++ b/app/controllers/trainings_controller.rb
@@ -10,6 +10,7 @@ class TrainingsController < ApplicationController
   def new
     @training = Training.new
     @targets = Target.all
+    @remaining_ai_usage = AiUsageService.remaining_count(current_user)
   end
 
   def create

--- a/app/controllers/trainings_controller.rb
+++ b/app/controllers/trainings_controller.rb
@@ -42,6 +42,7 @@ class TrainingsController < ApplicationController
 
     @training ||= current_user.trainings.build(training_params)
     @targets = Target.all
+    @remaining_ai_usage = AiUsageService.remaining_count(current_user)
 
     flash.now[:alert] = "AIフィードバックの生成に失敗しました"
 

--- a/app/services/ai_usage_service.rb
+++ b/app/services/ai_usage_service.rb
@@ -1,0 +1,26 @@
+class AiUsageService
+  BASE_LIMIT = 3
+  BONUS_LIMIT = 2
+
+  def self.redis_key(user)
+    "ai_usage:#{user.id}"
+  end
+
+  def self.usage_count(user)
+    (REDIS.get(redis_key(user)) || 0).to_i
+  end
+
+  def self.today_limit(user)
+    limit = BASE_LIMIT
+
+    if user.posts.where(created_at: Time.zone.today.all_day).exists?
+      limit += BONUS_LIMIT
+    end
+
+    limit
+  end
+
+  def self.remaining_count(user)
+    [today_limit(user) - usage_count(user), 0].max
+  end
+end

--- a/app/services/ai_usage_service.rb
+++ b/app/services/ai_usage_service.rb
@@ -21,7 +21,7 @@ class AiUsageService
   end
 
   def self.remaining_count(user)
-    [today_limit(user) - usage_count(user), 0].max
+    [ today_limit(user) - usage_count(user), 0 ].max
   end
 
   def self.increment(user)

--- a/app/services/ai_usage_service.rb
+++ b/app/services/ai_usage_service.rb
@@ -23,4 +23,19 @@ class AiUsageService
   def self.remaining_count(user)
     [today_limit(user) - usage_count(user), 0].max
   end
+
+  def self.increment(user)
+    key = redis_key(user)
+
+    REDIS.incr(key)
+
+    unless REDIS.ttl(key).positive?
+      REDIS.expire(key, seconds_until_midnight)
+    end
+  end
+
+  def self.seconds_until_midnight
+    tomorrow = Time.zone.tomorrow.beginning_of_day
+    (tomorrow - Time.zone.now).to_i
+  end
 end

--- a/app/services/ai_usage_service.rb
+++ b/app/services/ai_usage_service.rb
@@ -26,9 +26,9 @@ class AiUsageService
 
   def self.increment(user)
     key = redis_key(user)
-
     REDIS.incr(key)
 
+    # ttl = Time To Live（後何秒で消えるか）
     unless REDIS.ttl(key).positive?
       REDIS.expire(key, seconds_until_midnight)
     end
@@ -37,5 +37,9 @@ class AiUsageService
   def self.seconds_until_midnight
     tomorrow = Time.zone.tomorrow.beginning_of_day
     (tomorrow - Time.zone.now).to_i
+  end
+
+  def self.limit_reached?(user)
+    remaining_count(user).zero?
   end
 end

--- a/app/views/trainings/new.html.erb
+++ b/app/views/trainings/new.html.erb
@@ -1,50 +1,65 @@
-<div class="w-full max-w-2xl bg-white rounded-2xl shadow-md p-8">
+<div class="flex justify-between items-start mb-6">
+  <div>
+    <h1 class="text-2xl font-bold text-amber-500">
+      📝 言語化トレーニング
+    </h1>
 
-  <h1 class="text-2xl font-bold text-amber-500 mb-6">
-    📝 言語化トレーニング
-  </h1>
+    <p class="text-gray-500 mt-2">
+      テーマを決めて、相手に伝える形で書いてみましょう
+    </p>
+  </div>
 
-  <p class="text-gray-500 mb-6">
-    テーマを決めて、相手に伝える形で書いてみましょう
-  </p>
+  <div
+    class="rounded-lg px-4 py-2 text-sm font-semibold
+      <%= @remaining_ai_usage.zero? ? 'bg-red-100 text-red-700 border border-red-300' : 'bg-blue-100 text-blue-700 border border-blue-300' %>">
 
-    <%= form_with model: @training, url: trainings_path, local: true do |f| %>
-      <div class="space-y-5">
+    AI利用可能回数<br>
 
-        <% if @training.errors.any? %>
-        <div class="bg-red-100 text-red-700 p-4 rounded-lg">
-          <ul>
-            <% @training.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
-            <% end %>
-          </ul>
-        </div>
+    <span class="text-lg">
+      残り <%= @remaining_ai_usage %> 回
+    </span>
+  </div>
+</div>
+
+<%= form_with model: @training, url: trainings_path, local: true do |f| %>
+  <div class="space-y-5">
+
+    <% if @training.errors.any? %>
+    <div class="bg-red-100 text-red-700 p-4 rounded-lg">
+      <ul>
+        <% @training.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
         <% end %>
-
+      </ul>
+    </div>
+    <% end %>
+    <div class="grid grid-cols-2 gap-4">
+      <div>
         <%= f.label :theme, "テーマ", class: "block text-sm font-semibold text-gray-600 mb-1" %>
         <%= f.text_field :theme,
           placeholder: "説明するテーマを入力してください",
-          class: "w-full px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
-
+          class: "w-full bg-white px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
+      </div>
+      <div>
         <%= f.label :target_id, "説明する相手", class: "block text-sm font-semibold text-gray-600 mb-1" %>
         <%= f.collection_select :target_id, @targets, :id, :name, {},
-          class: "w-full px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
-
-        <div id="custom-target-field" class="<%= 'hidden' unless @training.target&.name == 'その他' %>">
-          <%= f.label :custom_target, "その他の相手", class: "block text-sm font-semibold text-gray-600 mb-1" %>
-          <%= f.text_field :custom_target,
-            placeholder: "説明したい相手を入力してください",
-            class: "w-full px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
-        </div>
-
-        <%= f.label :explanation, "説明内容", class: "block text-sm font-semibold text-gray-600 mb-1" %>
-        <%= f.text_area :explanation,
-          placeholder: "相手に合わせて説明してみましょう",
-          class: "w-full h-40 px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
-
-        <%= f.submit "トレーニング完了",
-          class: "w-full bg-amber-400 hover:bg-amber-500 text-white font-bold py-3 rounded-lg" %>
-
+          class: "w-full bg-white px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
       </div>
-    <% end %>
-</div>
+      <div id="custom-target-field" class="<%= 'hidden' unless @training.target&.name == 'その他' %>">
+        <%= f.label :custom_target, "その他の相手", class: "block text-sm font-semibold text-gray-600 mb-1" %>
+        <%= f.text_field :custom_target,
+          placeholder: "説明したい相手を入力してください",
+          class: "w-full bg-white px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
+      </div>
+    </div>
+
+    <%= f.label :explanation, "説明内容", class: "block text-sm font-semibold text-gray-600 mb-1" %>
+    <%= f.text_area :explanation,
+      placeholder: "相手に合わせて説明してみましょう",
+      class: "w-full bg-white h-40 px-4 py-2 border border-amber-200 rounded-lg focus:ring-2 focus:ring-amber-400" %>
+
+    <%= f.submit "トレーニング完了",
+      class: "w-full bg-amber-400 hover:bg-amber-500 text-white font-bold py-3 rounded-lg" %>
+
+  </div>
+<% end %>

--- a/compose.yml
+++ b/compose.yml
@@ -14,6 +14,16 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+  redis:
+    image: redis:7-alpine
+    restart: always
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   web:
     build:
       context: .
@@ -31,6 +41,8 @@ services:
       - "3000:3000"
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 volumes:
   bundle_data:

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,1 @@
+REDIS = Redis.new(url: ENV.fetch("REDIS_URL", "redis://redis:6379/0"))


### PR DESCRIPTION
## 概要

1日のAIフィードバック利用回数制限を実装

close #72 

## 実装内容
- Redisを導入し、AI利用回数を管理
- AiUsageServiceを作成
- AI利用回数の上限チェックを実装
- AI処理をトランザクション化
- 残り利用可能回数をトレーニング画面に表示

## 動作確認
- AI利用可能回数がトレーニング画面に表示される
- 上限に達するとAI利用制限がかかる
- 投稿すると2回追加される