### PR TITLE
思考力モードの基盤を作成

### DIFF
--- a/app/controllers/thinking_modes_controller.rb
+++ b/app/controllers/thinking_modes_controller.rb
@@ -1,0 +1,4 @@
+class ThinkingModesController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/thinking_modes_controller.rb
+++ b/app/controllers/thinking_modes_controller.rb
@@ -1,4 +1,5 @@
 class ThinkingModesController < ApplicationController
-  def index
-  end
+  before_action :authenticate_user!
+
+  def index; end
 end

--- a/app/helpers/thinking_modes_helper.rb
+++ b/app/helpers/thinking_modes_helper.rb
@@ -1,0 +1,2 @@
+module ThinkingModesHelper
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,16 +1,45 @@
-<!-- コンテンツ -->
 <div class="flex flex-col items-center justify-center h-[80vh] p-6">
+  <h2 class="text-lg text-gray-700 mb-8">
+    今日もトレーニングしましょう 💪
+  </h2>
 
-  <!-- メインCTA -->
-  <div class="w-full max-w-md text-center">
-    <h2 class="text-lg text-gray-700 mb-6">
-      今日もトレーニングしましょう 💪
-    </h2>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-4xl">
+    <%= link_to new_training_path, class: "bg-white rounded-2xl shadow-lg border border-gray-200 p-8 hover:shadow-xl hover:-translate-y-1 transition" do %>
 
-    <%= link_to new_training_path,
-      class: "block w-full bg-blue-600 hover:bg-blue-700 text-white text-lg font-bold py-4 rounded-xl shadow-lg transition" do %>
-      トレーニングを始める
+      <div class="text-center">
+        <div class="text-5xl mb-4">
+          📝
+        </div>
+
+        <h3 class="text-xl font-bold text-gray-800 mb-2">
+          通常モード
+        </h3>
+
+        <p class="text-gray-500 text-sm">
+          AIからフィードバックを受けながら
+          言語化力を鍛えます。
+        </p>
+      </div>
+
+    <% end %>
+
+    <%= link_to thinking_modes_path, class: "bg-white rounded-2xl shadow-lg border border-gray-200 p-8 hover:shadow-xl hover:-translate-y-1 transition" do %>
+
+      <div class="text-center">
+        <div class="text-5xl mb-4">
+          🧠
+        </div>
+
+        <h3 class="text-xl font-bold text-gray-800 mb-2">
+          思考力モード
+        </h3>
+
+        <p class="text-gray-500 text-sm">
+          AIとの対話を通して
+          思考力を鍛えます。
+        </p>
+      </div>
+
     <% end %>
   </div>
-
 </div>

--- a/app/views/thinking_modes/index.html.erb
+++ b/app/views/thinking_modes/index.html.erb
@@ -1,2 +1,24 @@
-<h1>ThinkingModes#index</h1>
-<p>Find me in app/views/thinking_modes/index.html.erb</p>
+<h1 class="text-2xl font-bold text-amber-500 mb-6">
+  🧠 思考力トレーニング
+</h1>
+
+<p class="text-gray-500 mb-8">
+  AIとの対話を通して思考力を鍛えましょう。
+</p>
+
+<label class="block mb-2 font-semibold">
+テーマ
+</label>
+
+<input
+type="text"
+disabled
+placeholder="近日実装予定"
+class="w-full rounded-lg border border-gray-300 px-4 py-2 bg-gray-100">
+
+<button
+disabled
+class="mt-6 w-full bg-gray-300 text-white rounded-lg py-3">
+
+準備中
+</button>

--- a/app/views/thinking_modes/index.html.erb
+++ b/app/views/thinking_modes/index.html.erb
@@ -1,0 +1,2 @@
+<h1>ThinkingModes#index</h1>
+<p>Find me in app/views/thinking_modes/index.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "thinking_modes/index"
   get "contacts/show"
   get "settings/index"
   devise_for :users,
@@ -18,6 +19,7 @@ Rails.application.routes.draw do
     resource :favorite, only: %i[create destroy]
   end
 
+  resources :thinking_modes, only: :index
   resources :posts, only: :index
   resources :favorites, only: :index
 

--- a/spec/helpers/thinking_modes_helper_spec.rb
+++ b/spec/helpers/thinking_modes_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ThinkingModesHelper. For example:
+#
+# describe ThinkingModesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ThinkingModesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/thinking_modes_spec.rb
+++ b/spec/requests/thinking_modes_spec.rb
@@ -2,8 +2,15 @@ require 'rails_helper'
 
 RSpec.describe "ThinkingModes", type: :request do
   describe "GET /index" do
+    let(:user) { create(:user) }
+
+    before do
+      sign_in user
+    end
+
     it "returns http success" do
-      get "/thinking_modes/index"
+      get thinking_modes_path
+
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/requests/thinking_modes_spec.rb
+++ b/spec/requests/thinking_modes_spec.rb
@@ -7,5 +7,4 @@ RSpec.describe "ThinkingModes", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/requests/thinking_modes_spec.rb
+++ b/spec/requests/thinking_modes_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "ThinkingModes", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/thinking_modes/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/thinking_modes/index.html.erb_spec.rb
+++ b/spec/views/thinking_modes/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "thinking_modes/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要

思考力モード画面の基盤を作成しました。

close #98 

## 実装内容

* 思考力モード用のルーティングを追加
* ホーム画面に「通常モード」「思考力モード」の選択カードを追加
* 思考力モード画面のUIを作成
* 認証必須設定を追加し、RSpecを対応

## 動作確認

ホーム画面から「通常モード」「思考力モード」を選択して遷移できる
